### PR TITLE
Update Ubuntu PPA URL

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -83,7 +83,7 @@
       on your ColorHug.</p>
       <p>
       Packages for Ubuntu can be found
-      <a href="https://launchpad.net/~pmjdebruijn/+archive/gcm-colorhug/">here</a>
+      <a href="https://launchpad.net/~pmjdebruijn/+archive/gnome-color-manager-release">here</a>
       courtesy of Pascal de Bruijn.
       </p>
 


### PR DESCRIPTION
Pascal seems to have started building packages to a new PPA and stopped updating the original one.
